### PR TITLE
Replace requirements.txt with explicit python-packages in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,11 @@ apps:
 parts:
   lets:
     plugin: python
-    requirements:
-      - requirements.txt
+    python-packages:
+      - docopt
+      - PyYaml
+      - terminaltables
+      - parsedatetime
+      - raffaello
     source: https://github.com/clobrano/letsdo.git
 


### PR DESCRIPTION
## Summary
Updated the snapcraft configuration to explicitly list Python package dependencies instead of referencing an external requirements.txt file.

## Changes
- Replaced `requirements: [requirements.txt]` with `python-packages:` configuration
- Explicitly declared all required Python packages:
  - docopt
  - PyYaml
  - terminaltables
  - parsedatetime
  - raffaello

## Details
This change improves the snap build process by making dependencies explicit and self-contained within the snapcraft.yaml file. This approach:
- Eliminates the need for an external requirements.txt file during snap builds
- Makes dependencies immediately visible in the snap configuration
- Reduces potential build failures due to missing or inaccessible requirement files
- Aligns with snapcraft best practices for simple dependency lists

https://claude.ai/code/session_01FTmAiuxKpXsAwjMhpT3GQf