### PR TITLE
Add build steps to PyPI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,13 +6,29 @@ jobs:
   pypi-publish:
     name: upload release to PyPI
     runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
     environment: pypi
     permissions:
-      # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
+      contents: read
     steps:
-      # retrieve your distributions here
+      - name: Checkout latest tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
This PR enhances the PyPI release workflow by adding explicit build steps before publishing to PyPI. Previously, the workflow was incomplete with only a placeholder comment for retrieving distributions.

## Key Changes
- Added checkout step to retrieve the latest tag with full history
- Added Python 3.12 setup step
- Added build dependencies installation (pip and build package)
- Added explicit package build step using `python -m build`
- Added `contents: read` permission to the workflow permissions
- Removed unnecessary comments about optional environment specification

## Implementation Details
The workflow now follows a complete release pipeline:
1. Checks out the repository at the tagged release
2. Sets up Python 3.12 environment
3. Installs and upgrades pip, then installs the build package
4. Builds the distribution artifacts
5. Publishes the built distributions to PyPI

This ensures that distributions are properly built from source before being published, rather than relying on pre-built artifacts.

https://claude.ai/code/session_01HxnRvRRHaJetMjmYSRr3gK